### PR TITLE
Remove 'beacon' from eventMethod

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -604,10 +604,6 @@ ___TEMPLATE_PARAMETERS___
           {
             "displayValue": "GET",
             "value": "get"
-          },
-          {
-            "displayValue": "Beacon",
-            "value": "beacon"
           }
         ],
         "displayName": "Dispatch Method",


### PR DESCRIPTION
This PR removes the `beacon` eventMethod, which was deprecated in v4 of the JS tracker.